### PR TITLE
Updating default thumbprint and declaring some variable types

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -8,6 +8,7 @@ variable "url" {
 }
 
 variable "client_id_list" {
+  type    = list(string)
   default = [
     "sts.amazonaws.com"
   ]
@@ -16,8 +17,9 @@ variable "client_id_list" {
 # This is the thumbprint returned if you were to create an "identity provider" in AWS and gave
 # it this url: https://token.actions.githubusercontent.com
 variable "thumbprint_list" {
+  type    = list(string)
   default = [
-    "a031c46782e6e6c662c2c87c76da9aa62ccabd8e"
+    "6938fd4d98bab03faadb97b34396831e3780aea1"
   ]
 }
 


### PR DESCRIPTION
According to a recent [GitHub's blog post](https://github.blog/changelog/2022-01-13-github-actions-update-on-oidc-based-deployments-to-aws/), the thumbprint for the identity provider used by GitHub Actions changed after an SSL certificate update. This PR updates the default value of the thumbprint accordingly.

Also, overriding that variable's default value doesn't work in terragrunt if the variable type is not explicitly set (e.g. https://github.com/gruntwork-io/terragrunt/issues/1007), so I have updated that as well.