### PR TITLE
Add additional thumbprint

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -19,7 +19,8 @@ variable "client_id_list" {
 variable "thumbprint_list" {
   type = list(string)
   default = [
-    "6938fd4d98bab03faadb97b34396831e3780aea1"
+    "6938fd4d98bab03faadb97b34396831e3780aea1",
+    "1c58a3a8518e8759bf075b76b750d4f2df264fcd"
   ]
 }
 


### PR DESCRIPTION
There are multiple intermediary certificats for the Actions SSL. This change adds the second thumbrint.

See
https://github.com/aws-actions/configure-aws-credentials/commit/0270d0bcecaf2c76c8fbf7bf3de0d65a6d06e076 for additional information.