### PR TITLE
make StringEquals []

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -42,7 +42,7 @@ EOT
 variable "validate_conditions" {
   description = "Conditions to validate"
   type        = set(string)
-  default     = ["repo:octo-org/octo-repo:ref:refs/heads/octo-branch"]
+  default     = []
 }
 
 variable "validate_wildcard_conditions" {


### PR DESCRIPTION
Making validate_conditions default [] to use validate_wildcard_conditions .
validate_wildcard_conditions adds `StringLike`  and validate_conditions adds 'StringEquals` 
StringEquals always overrides the StringLike with some default value