### PR TITLE
Adding a new input parameter for max session duration

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -1,12 +1,8 @@
 resource "aws_iam_openid_connect_provider" "this" {
   count = var.create_identity_provider ? 1 : 0
-
   url = var.url
-
   client_id_list = var.client_id_list
-
   thumbprint_list = var.thumbprint_list
-
   tags = var.tags
 }
 
@@ -19,6 +15,7 @@ module "iam_assumable_role_admin" {
   role_policy_arns              = [aws_iam_policy.iam_policy.arn]
   oidc_fully_qualified_subjects = var.validate_conditions
   oidc_subjects_with_wildcards  = var.validate_wildcard_conditions
+  max_session_duration          = var.max_session_duration
   tags                          = var.tags
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -62,3 +62,9 @@ variable "create_identity_provider" {
   default     = true
   description = "This switch allows you to create or not create the identity provider.  Only one can exist.  If you are creating multiple Github OIDC Federations, only one of the instantiations should create this or the Terraform run will fail."
 }
+
+variable "max_session_duration" {
+  type        = number
+  default     = 3600
+  description = "The maximum session duration for the role in seconds"
+}


### PR DESCRIPTION
### Title
terraform-aws-github-oidc-provider: add `max_session_duration` input to configure IAM role session duration

### Summary
Adds a new input variable `max_session_duration` to allow configuring the AWS IAM role session duration (in seconds) for roles created by this module.

### What changed
- Introduced `variable "max_session_duration"` with:
  - default: `3600` (1 hour)
  - type: `number`
  - description: “The maximum session duration for the role in seconds”
- Threaded the value to the IAM role’s `max_session_duration` to enforce the configured session length.

### Why
- Some workflows (e.g., long-running CI jobs) require sessions longer than the default 1 hour.
- This makes session duration configurable without forking the module.

### Impact
- Backwards compatible: default remains 1 hour, no change for existing users unless they set this variable.

### Usage
```hcl
module "github_oidc_provider" {
  source = "..."

  # Optional: increase to e.g., 2 hours
  max_session_duration = 7200
}
```

### Testing
- `terraform validate` passes.
- Ran `terraform plan` with default and custom values (e.g., 7200) to verify the role updates as expected.

### Notes
- AWS currently permits up to 12 hours for role session duration (service/role-dependent). See AWS IAM docs: [View and set role maximum session duration](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_use.html#id_roles_use_view-role-max-session-duration).

